### PR TITLE
adjust minimum width stream search bar

### DIFF
--- a/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml
+++ b/DesktopUI2/DesktopUI2/Views/Windows/Dialogs/NewStreamDialog.xaml
@@ -87,7 +87,7 @@
 			</ComboBox>
 			<Grid>
 				<Grid.ColumnDefinitions>
-					<ColumnDefinition Width="*" MinWidth="300"/>
+					<ColumnDefinition Width="*" MinWidth="100"/>
 					<ColumnDefinition Width="auto"/>
 				</Grid.ColumnDefinitions>
 


### PR DESCRIPTION
Update job number search box minimum width to provide better readability when docking connector in Revit/Rhino.