### PR TITLE
Gsa revit compat

### DIFF
--- a/Objects/Converters/ConverterGSA/ConverterGSA/ConverterGSA.ToSpeckle.cs
+++ b/Objects/Converters/ConverterGSA/ConverterGSA/ConverterGSA.ToSpeckle.cs
@@ -592,7 +592,7 @@ namespace ConverterGSA
       if (gsaMemb.NodeIndices.Count >= 3)
       {
         var topology = gsaMemb.NodeIndices.Select(i => GetNodeFromIndex(i)).ToList();
-        //speckleMember2d.topology = topology;
+        speckleMember2d.topology = topology;
 
         var nodeAddIds = topology.Select(n => n.applicationId).ToList();
         speckleMember2d.topologyRefs = nodeAddIds;

--- a/Objects/Converters/ConverterGSA/ConverterGSA/ConverterGSA.ToSpeckle.cs
+++ b/Objects/Converters/ConverterGSA/ConverterGSA/ConverterGSA.ToSpeckle.cs
@@ -307,8 +307,12 @@ namespace ConverterGSA
         colour = gsaEl.Colour.ToString(),
         isDummy = gsaEl.Dummy,
         action = "NORMAL", //TODO: update if interim schema is updated
-        parentApplicationId = Instance.GsaModel.Cache.GetApplicationId<GsaMemb>(gsaEl.ParentIndex.Value)
       };
+
+      if (gsaEl.ParentIndex.IsIndex())
+      {
+        speckleElement1d.parentApplicationId = Instance.GsaModel.Cache.GetApplicationId<GsaMemb>(gsaEl.ParentIndex.Value);
+      }
 
       if (gsaEl.Index.IsIndex())
       {

--- a/Objects/Converters/ConverterGSA/ConverterGSA/ConverterGSA.ToSpeckle.cs
+++ b/Objects/Converters/ConverterGSA/ConverterGSA/ConverterGSA.ToSpeckle.cs
@@ -307,6 +307,7 @@ namespace ConverterGSA
         colour = gsaEl.Colour.ToString(),
         isDummy = gsaEl.Dummy,
         action = "NORMAL", //TODO: update if interim schema is updated
+        parentApplicationId = Instance.GsaModel.Cache.GetApplicationId<GsaMemb>(gsaEl.ParentIndex.Value)
       };
 
       if (gsaEl.Index.IsIndex())
@@ -1926,7 +1927,7 @@ namespace ConverterGSA
       //  string description
     }
 
-    public bool GsaElement1dResultToSpeckle(int gsaElementIndex, Element1D speckleElement, out List<Result1D> speckleResults)
+    public bool GsaElement1dResultToSpeckle(int gsaElementIndex, GSAElement1D speckleElement, out List<Result1D> speckleResults)
     {
       speckleResults = null;
       if (Instance.GsaModel.Proxy.GetResultRecords(ResultGroup.Elem_1d, gsaElementIndex, out var csvRecord))
@@ -1940,7 +1941,7 @@ namespace ConverterGSA
             description = "",
             permutation = "",
             //element = speckleElement,
-            elementRef = speckleElement.applicationId,
+            elementRef = speckleElement.parentApplicationId,
             position = float.Parse(gsaResult.PosR),
           };
 

--- a/Objects/Objects/Structural/ApplicationSpecific/GSA/Geometry/GSAElement1D.cs
+++ b/Objects/Objects/Structural/ApplicationSpecific/GSA/Geometry/GSAElement1D.cs
@@ -15,6 +15,7 @@ namespace Objects.Structural.GSA.Geometry
     public string colour { get; set; }
     public string action { get; set; }
     public bool isDummy { get; set; }
+    public string parentApplicationId { get; set; }
     //public ElementType1D type { get; set; }
     public GSAElement1D() { }
 


### PR DESCRIPTION
## Description

- Fixes 2D element conversion into Revit
- GSAElement1D now references parent GSAMember1D id

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Tests: tested send and receive

## Docs

- No updates needed

