### PR TITLE
Fix: standalone (gsa) ui branch selection

### DIFF
--- a/DesktopUI2/DesktopUI2/Views/Pages/StreamEditControls/ReceiveGSA.axaml
+++ b/DesktopUI2/DesktopUI2/Views/Pages/StreamEditControls/ReceiveGSA.axaml
@@ -26,10 +26,11 @@
           <TextBlock Text="Receiving " />
           <TextBlock FontWeight="Bold" Text="{Binding SelectedCommit.id, FallbackValue=?}" />
           <TextBlock Text=" from " />
-          <TextBlock FontWeight="Bold" Text="{Binding SelectedBranch.name, FallbackValue=?}" />
+          <TextBlock FontWeight="Bold" Text="{Binding SelectedBranch.Branch.name, FallbackValue=?}" />
+					<TextBlock Classes="Overline" Foreground="Gray" Text="  (expand to edit)" />
         </StackPanel>
       </Expander.Header>
-      <Grid ColumnDefinitions="auto,*, auto, *" RowDefinitions="auto, auto,auto">
+      <Grid Margin="15,0" ColumnDefinitions="auto,*, auto, *" RowDefinitions="auto, auto,auto,auto">
 
         <!--  SELECT BRANCH  -->
         <icons:MaterialIcon
@@ -43,7 +44,7 @@
           Margin="5,10,5,10"
           HorizontalAlignment="Stretch"
           VerticalAlignment="Center"
-          Items="{Binding Branches}"
+          Items="{Binding BranchesViewModel}"
           PlaceholderText="Select a branch"
           SelectedItem="{Binding SelectedBranch}">
           <ComboBox.ItemTemplate>
@@ -52,10 +53,10 @@
                 <icons:MaterialIcon
                   Margin="0,0,5,0"
                   Foreground="DarkGray"
-                  Kind="SourceBranch" />
+                  Kind="{Binding Icon}" />
                 <TextBlock
                   Grid.Column="1"
-                  Text="{Binding name}"
+                  Text="{Binding Branch.name}"
                   TextTrimming="CharacterEllipsis" />
               </Grid>
             </DataTemplate>
@@ -199,7 +200,7 @@
           assists:ShadowAssist.ShadowDepth="Depth0"
           Background="Transparent"
           Command="{Binding SaveCommand}"
-          IsEnabled="{Binding Progress.IsProgressing, Converter={x:Static BoolConverters.Not}}"
+          IsEnabled="{Binding !Progress.IsProgressing}"
           ToolTip.Tip="Save this sender to the file without sending">
           <Button.Content>
             <icons:MaterialIcon

--- a/DesktopUI2/DesktopUI2/Views/Pages/StreamEditControls/SendGSA.axaml
+++ b/DesktopUI2/DesktopUI2/Views/Pages/StreamEditControls/SendGSA.axaml
@@ -30,11 +30,12 @@
 					<TextBlock Text="Sending " />
 					<TextBlock FontWeight="Bold" Text="{Binding SelectedFilter.Summary, FallbackValue=?}" />
 					<TextBlock Text=" to " />
-					<TextBlock FontWeight="Bold" Text="{Binding SelectedBranch.name, FallbackValue=?}" />
+					<TextBlock FontWeight="Bold" Text="{Binding SelectedBranch.Branch.name, FallbackValue=?}" />
+					<TextBlock Classes="Overline" Foreground="Gray" Text="  (expand to edit)" />
 				</StackPanel>
 			</Expander.Header>
 
-			<Grid ColumnDefinitions="auto,*,auto, *" RowDefinitions="auto, auto, auto, auto">
+			<Grid Margin="15,0" ColumnDefinitions="auto,*,auto, *" RowDefinitions="auto, auto, auto">
 
 				<!--  SELECT BRANCH  -->
 				<icons:MaterialIcon
@@ -48,19 +49,19 @@
 				  Margin="5,10,5,10"
 				  HorizontalAlignment="Stretch"
 				  VerticalAlignment="Center"
-				  Items="{Binding Branches}"
+				  Items="{Binding BranchesViewModel}"
 				  PlaceholderText="Select a branch"
-				  SelectedItem="{Binding SelectedBranch}">
+				  SelectedItem="{Binding SelectedBranch, Mode=TwoWay}">
 					<ComboBox.ItemTemplate>
 						<DataTemplate>
 							<Grid ColumnDefinitions="auto,*">
 								<icons:MaterialIcon
 								  Margin="0,0,5,0"
 								  Foreground="DarkGray"
-								  Kind="SourceBranch" />
+								  Kind="{Binding Icon}" />
 								<TextBlock
 								  Grid.Column="1"
-								  Text="{Binding name}"
+								  Text="{Binding Branch.name}"
 								  TextTrimming="CharacterEllipsis" />
 							</Grid>
 						</DataTemplate>
@@ -227,7 +228,7 @@
 				  assists:ShadowAssist.ShadowDepth="Depth0"
 				  Background="Transparent"
 				  Command="{Binding SaveCommand}"
-				  IsEnabled="{Binding Progress.IsProgressing, Converter={x:Static BoolConverters.Not}}"
+				  IsEnabled="{Binding !Progress.IsProgressing}"
 				  ToolTip.Tip="Save this sender to the file without sending">
 					<Button.Content>
 						<icons:MaterialIcon


### PR DESCRIPTION
## Description & motivation

- Branch selection currently functional on DesktopUI2 but not on standalone version
- Applied changes from regular DUI2 to standalone

Before:
![image](https://user-images.githubusercontent.com/77862637/212370285-8f90e90c-7fbc-486d-9337-483a9d0908f5.png)

After:
![image](https://user-images.githubusercontent.com/77862637/212370931-5d382fa1-afc6-4ad9-ba6a-3a71ff214fec.png)


## Validation of changes:

- Manually tested send/receive to multiple branches with GSA connector
