### PR TITLE
fix: gsa receive conversion hang on null properties

### DIFF
--- a/ConnectorGSA/ConnectorGSA2/Commands.cs
+++ b/ConnectorGSA/ConnectorGSA2/Commands.cs
@@ -65,7 +65,7 @@ namespace ConnectorGSA
         {
           loggingProgress.Report(new MessageEventArgs(MessageIntent.Display, MessageLevel.Error, "Unable to get stream list"));
         }
-        
+
 
         coordinator.Account = accountCandidate;
         coordinator.ServerStreamList.StreamListItems.Clear();
@@ -127,21 +127,22 @@ namespace ConnectorGSA
     }
 
     public static bool ExtractSavedReceptionStreamInfo(bool? receive, bool? send, out List<StreamState> streamStates)
-    { 
+    {
       List<StreamState> allSaved;
       try
       {
         var sid = ((GsaProxy)Instance.GsaModel.Proxy).GetTopLevelSid();
         allSaved = JsonConvert.DeserializeObject<List<StreamState>>(sid);
-        if (allSaved == null) {
+        if (allSaved == null)
+        {
           allSaved = new List<StreamState>();
         }
       }
       catch
       {
         allSaved = new List<StreamState>();
-      }      
-      
+      }
+
       var userId = ((GsaModel)Instance.GsaModel).Account.userInfo.id;
       var restApi = ((GsaModel)Instance.GsaModel).Account.serverInfo.url;
 
@@ -160,8 +161,8 @@ namespace ConnectorGSA
     }
 
     public static bool UpsertSavedReceptionStreamInfo(bool? receive, bool? send, params StreamState[] streamStates)
-    {            
-      if(((GsaProxy)Instance.GsaModel.Proxy) != null)
+    {
+      if (((GsaProxy)Instance.GsaModel.Proxy) != null)
       {
         var sid = ((GsaProxy)Instance.GsaModel.Proxy).GetTopLevelSid();
         List<StreamState> allSs = null;
@@ -205,10 +206,11 @@ namespace ConnectorGSA
 
         var newSid = JsonConvert.SerializeObject(allSs);
         return ((GsaProxy)Instance.GsaModel.Proxy).SetTopLevelSid(newSid);
-      } else
+      }
+      else
       {
         return false;
-      }      
+      }
     }
 
     public static bool CloseFile(string filePath, bool visible)
@@ -220,7 +222,7 @@ namespace ConnectorGSA
     public static bool LoadDataFromFile(ProgressViewModel progress = null, IEnumerable<ResultGroup> resultGroups = null, IEnumerable<ResultType> resultTypes = null, List<string> cases = null, List<int> elemIds = null)
     {
       ((GsaProxy)Instance.GsaModel.Proxy).Clear();
-      
+
       var loadedCache = UpdateCache(progress);
       int cumulativeErrorRows = 0;
 
@@ -312,7 +314,7 @@ namespace ConnectorGSA
         onErrorAction: (s, e) =>
         {
           progress.Report.LogOperationError(e);
-          if(e.InnerException != null) progress.Report.LogOperationError(e.InnerException);
+          if (e.InnerException != null) progress.Report.LogOperationError(e.InnerException);
           progress.CancellationTokenSource.Cancel();
         },
         disposeTransports: false
@@ -327,7 +329,7 @@ namespace ConnectorGSA
     public static async Task<string> SendCommit(Base commitObj, DesktopUI2.Models.StreamState state, ProgressViewModel progress, string parent, params ITransport[] transports)
     {
       var objId = await Commands.SendObject(commitObj, progress, transports);
-      if(objId != null)
+      if (objId != null)
       {
         if (transports.Any(t => t is ServerTransport))
         {
@@ -672,7 +674,7 @@ namespace ConnectorGSA
     private static bool UpdateCache(ProgressViewModel progress = null, bool onlyNodesWithApplicationIds = true)
     {
       var errored = new Dictionary<int, GsaRecord>();
-      
+
       try
       {
         if (((GsaProxy)Instance.GsaModel.Proxy).GetGwaData(Instance.GsaModel.StreamLayer, progress, out var records, null))
@@ -686,7 +688,7 @@ namespace ConnectorGSA
             }
           }
         }
-       return true;
+        return true;
       }
       catch
       {
@@ -728,14 +730,12 @@ namespace ConnectorGSA
         }
         else
         {
-          foreach (var prop in @base.GetDynamicMembers())
+          foreach (var prop in @base.GetDynamicMemberNames())
           {
-            objects.AddRange(FlattenCommitObject(@base[prop], IsSingleObjectFn, uniques));
-          }
-          foreach (var kvp in @base.GetMembers())
-          {
-            var prop = kvp.Key;
-            objects.AddRange(FlattenCommitObject(@base[prop], IsSingleObjectFn, uniques));
+            if (@base[prop] != null)
+            {
+              objects.AddRange(FlattenCommitObject(@base[prop], IsSingleObjectFn, uniques));
+            }
           }
           return objects;
         }
@@ -904,7 +904,7 @@ namespace ConnectorGSA
       return true;
     }
 
-    internal static async Task<bool> SendTriggered(TabCoordinator coordinator, IProgress<MessageEventArgs> loggingProgress, 
+    internal static async Task<bool> SendTriggered(TabCoordinator coordinator, IProgress<MessageEventArgs> loggingProgress,
       IProgress<string> statusProgress, IProgress<double> percentageProgress)
     {
       var result = await Send(coordinator, coordinator.SenderTab.SenderStreamStates.First(), loggingProgress, statusProgress, percentageProgress);
@@ -1117,7 +1117,7 @@ namespace ConnectorGSA
       return true;
     }
 
-    internal static async Task<bool> SendInitial(TabCoordinator coordinator, IProgress<StreamState> streamCreationProgress, IProgress<StreamStateOld> streamDeletionProgress, 
+    internal static async Task<bool> SendInitial(TabCoordinator coordinator, IProgress<StreamState> streamCreationProgress, IProgress<StreamStateOld> streamDeletionProgress,
       IProgress<MessageEventArgs> loggingProgress, IProgress<string> statusProgress, IProgress<double> percentageProgress)
     {
       Instance.GsaModel.StreamLayer = coordinator.SenderTab.TargetLayer;
@@ -1150,7 +1150,7 @@ namespace ConnectorGSA
           ((GsaModel)Instance.GsaModel).LastCommitId = mainBranch.commits.items[0].id;
         }
       }
-      
+
       streamCreationProgress.Report(streamState); //This will add it to the sender tab's streamState list
 
       await Send(coordinator, streamState, loggingProgress, statusProgress, percentageProgress);


### PR DESCRIPTION
## Description & motivation

- Bug highlighted when objects containing a bbox value of null was causing flattening of received commit object to hang
- Conversion previously used GetMembers method (from core) which tries to get value of each property. This will hang when any value is null.

## Changes:

- Condense two core methods used down to one which fetches only property names and then checks if value is null before trying to flatten that object.
- Does not change core, only GSA connector behaviour.
- General lint on file for fomatting

## Validation of changes:

- Tested receiving two different Revit models. One with just analytical, one with analytical and physical. Both times conversion was successful for supporting elements (i.e. unsupported physical objects were skipped)