### PR TITLE
Handle stream creation exception (stemming from Arup job number requi…

### DIFF
--- a/DesktopUI2/DesktopUI2/ViewModels/OneClickViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/OneClickViewModel.cs
@@ -135,6 +135,8 @@ namespace DesktopUI2.ViewModels
           }));
 
           MainViewModel.Instance.NavigateToDefaultScreen();
+
+          return;
         }
       }
 

--- a/DesktopUI2/DesktopUI2/ViewModels/OneClickViewModel.cs
+++ b/DesktopUI2/DesktopUI2/ViewModels/OneClickViewModel.cs
@@ -119,7 +119,25 @@ namespace DesktopUI2.ViewModels
       _fileName = fileName;
 
       if (_fileStream == null)
-        _fileStream = await GetOrCreateStreamState();
+      {
+        try
+        {
+          _fileStream = await GetOrCreateStreamState();
+        }
+        catch (SpeckleException ex)
+        {
+          Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+          Views.MainUserControl.NotificationManager.Show(new PopUpNotificationViewModel()
+          {
+            Title = "⚠️ Unable to fetch saved stream or create new.",
+            Message = $"{ex.Message}",
+            Type = Avalonia.Controls.Notifications.NotificationType.Error
+          }));
+
+          MainViewModel.Instance.NavigateToDefaultScreen();
+        }
+      }
+
       // check if objs are selected and set streamstate filter
       var filters = Bindings.GetSelectionFilters();
       var selection = Bindings.GetSelectedObjects();


### PR DESCRIPTION
## Description & motivation
OneClickSend attempts to create new stream if existing saved stream matching file name cannot be found. This gives an unhandled exception with Arup server because of job number requirement causing complete crash in Revit. 

## Changes:

- No current option for user to add a job number so handle exception with UI error instead.
- Reroute user back to one-click view once stream fails to create.

## Screenshots:

![image](https://user-images.githubusercontent.com/77862637/212348437-6d47a6a7-bcb1-48ea-a548-66b33b2ad5f1.png)

## Validation of changes:

Manually tested

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->

This PR replaces #216 which contains the same logic to fix this issue, but had code formatting issues in OneClickViewModel.cs that needed further investigation.
