### PR TITLE
Addition of new "Copy token" button in the Account Manager

### DIFF
--- a/Installer/ConnectionManager/SpeckleConnectionManagerUI/Models/ConnectStatusItem.cs
+++ b/Installer/ConnectionManager/SpeckleConnectionManagerUI/Models/ConnectStatusItem.cs
@@ -8,6 +8,8 @@ namespace SpeckleConnectionManagerUI.Models
     public string? ServerName { get; set; }
     public string? ServerUrl { get; set; }
 
+    public string? Id { get; set; }
+
     private string? _connectText;
     public string? ConnectText
     {

--- a/Installer/ConnectionManager/SpeckleConnectionManagerUI/Services/Database.cs
+++ b/Installer/ConnectionManager/SpeckleConnectionManagerUI/Services/Database.cs
@@ -25,6 +25,7 @@ namespace SpeckleConnectionManagerUI.Services
         connectStatus.Default = savedConnection.isDefault;
         connectStatus.DefaultServerLabel = connectStatus.Default ? "DEFAULT" : "SET AS DEFAULT";
         connectStatus.Colour = connectStatus.Disconnected ? "Red" : "Green";
+        connectStatus.Id = savedConnection.id;
 
         if (!connectStatuses.Contains(connectStatus)) connectStatuses.Add(connectStatus);
         identifier++;
@@ -63,6 +64,27 @@ namespace SpeckleConnectionManagerUI.Services
       }
 
       return connectStatuses.ToArray();
+    }
+
+    //If Token is added to the ConnectStatusItem class and assigned in the GetItems method above,
+    //it will be outdated by the scheduled TimedRefreshToken - hence a new connection to the DB is
+    //created here so that it can obtain the latest token from the DB when it's triggered by the
+    //COPY TOKEN button
+    public string GetToken(string id)
+    {
+      if (!string.IsNullOrEmpty(id))
+      {
+        var savedConnections = Sqlite.GetData();
+
+        foreach (var savedConnection in savedConnections)
+        {
+          if (!string.IsNullOrEmpty(savedConnection.id) && savedConnection.id.Equals(id))
+          {
+            return savedConnection.token;
+          }
+        }
+      }
+      return "";
     }
   }
 }

--- a/Installer/ConnectionManager/SpeckleConnectionManagerUI/ViewModels/MainWindowViewModel.cs
+++ b/Installer/ConnectionManager/SpeckleConnectionManagerUI/ViewModels/MainWindowViewModel.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using ReactiveUI;
 using SpeckleConnectionManagerUI.Views;
 using SpeckleConnectionManagerUI.Services;
+using Avalonia;
 
 namespace SpeckleConnectionManagerUI.ViewModels
 {
@@ -128,6 +129,22 @@ namespace SpeckleConnectionManagerUI.ViewModels
         Sqlite.RemoveServer(connectionStatusItem.ServerUrl);
 
       List.Items.Remove(connectionStatusItem);
+    }
+
+    public async Task CopyTokenToClipboardAsync(int identifier)
+    {
+      var connectionStatusItem = List.Items.FirstOrDefault(i => i.Identifier == identifier);
+      if (connectionStatusItem == null || connectionStatusItem.Id == null) return;
+
+      var db = new Database();
+
+      var token = db.GetToken(connectionStatusItem.Id);
+
+      //if (connectionStatusItem.Token != null && Application.Current != null && Application.Current.Clipboard != null)
+      if (token != null && Application.Current != null && Application.Current.Clipboard != null)
+      {
+        await Application.Current.Clipboard.SetTextAsync(token);
+      }
     }
 
     public void LaunchDocs()

--- a/Installer/ConnectionManager/SpeckleConnectionManagerUI/Views/ConnectStatusView.axaml
+++ b/Installer/ConnectionManager/SpeckleConnectionManagerUI/Views/ConnectStatusView.axaml
@@ -7,7 +7,7 @@
              xmlns:icons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:assists="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
              xmlns:vm="clr-namespace:SpeckleConnectionManagerUI.ViewModels"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="450"
              x:Class="SpeckleConnectionManagerUI.Views.ConnectStatusView">
   <Design.DataContext>
     <vm:ConnectStatusViewModel />
@@ -17,7 +17,7 @@
       <ItemsControl Margin="10 0 0 0" Items="{Binding Items}">
         <ItemsControl.ItemTemplate>
           <DataTemplate>
-            <Grid ShowGridLines="False" ColumnDefinitions="1.2*,3*,1.5*,1.2*" RowDefinitions="Auto,Auto">
+            <Grid ShowGridLines="False" ColumnDefinitions="1.7*,3.8*,1.5*,1.4*,1.7*" RowDefinitions="Auto,Auto">
               <Button FontSize="20"
                       Margin="0 5 10 5"
                       Grid.Row="0"
@@ -86,6 +86,21 @@
                   Foreground="White"
                   Text="REMOVE"/>
               </Button>
+			  <Button FontSize="10"
+					Margin="0 5 10 5"
+					Grid.Row="0"
+					Grid.Column="4"
+					Background="Gray"
+					assists:ShadowAssist.ShadowDepth="0"
+					Command="{Binding $parent[Window].DataContext.CopyTokenToClipboardAsync}"
+					CommandParameter="{Binding Identifier}">
+				<TextBlock
+				  VerticalAlignment="Center"
+				  FontSize="14"
+				  Classes="ButtonText"
+				  Foreground="White"
+				  Text="COPY TOKEN"/>
+			  </Button>
             </Grid>
           </DataTemplate>
         </ItemsControl.ItemTemplate>

--- a/Installer/ConnectionManager/SpeckleConnectionManagerUI/Views/ConnectStatusView.axaml
+++ b/Installer/ConnectionManager/SpeckleConnectionManagerUI/Views/ConnectStatusView.axaml
@@ -7,19 +7,19 @@
              xmlns:icons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:assists="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
              xmlns:vm="clr-namespace:SpeckleConnectionManagerUI.ViewModels"
-             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="450"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SpeckleConnectionManagerUI.Views.ConnectStatusView">
   <Design.DataContext>
     <vm:ConnectStatusViewModel />
   </Design.DataContext>
-  <Grid Margin="15" RowDefinitions="auto,auto,auto,auto, *, auto">
+  <Grid Margin="10" RowDefinitions="auto,auto,auto,auto, *, auto">
     <styles:Card Grid.Row="4" Padding="0,4">
-      <ItemsControl Margin="10 0 0 0" Items="{Binding Items}">
+      <ItemsControl Margin="10 0 5 0" Items="{Binding Items}">
         <ItemsControl.ItemTemplate>
           <DataTemplate>
-            <Grid ShowGridLines="False" ColumnDefinitions="1.7*,3.8*,1.5*,1.4*,1.7*" RowDefinitions="Auto,Auto">
-              <Button FontSize="20"
-                      Margin="0 5 10 5"
+            <Grid ShowGridLines="False" ColumnDefinitions="1.2*,3.6*,1.4*,0.9*,1.2*" RowDefinitions="Auto,Auto">
+              <Button Padding="5"
+                      Margin="0 5 5 5"
                       Grid.Row="0"
                       Grid.Column="0"
                       Foreground="White"
@@ -34,14 +34,14 @@
                   Text="{Binding ConnectText}"/>
               </Button>
               <TextBlock VerticalAlignment="Center"
-                         Margin="10 0 0 0"
-                         FontSize="20"
+                         Margin="5 0 0 0"
+                         FontSize="18"
                          Grid.Row="0"
                          Grid.Column="1"
                          Text="{Binding ServerUrl}"
                          Foreground="{Binding Colour}" />
-              <Button FontSize="20"
-                      Margin="0 5 10 5"
+              <Button Padding="5"
+                      Margin="0 5 5 5"
                       Grid.Row="0"
                       Grid.Column="2"
                       IsVisible="{Binding Default}"
@@ -55,8 +55,8 @@
                   Foreground="White"
                   Text="{Binding DefaultServerLabel}"/>  
               </Button>
-              <Button FontSize="20"
-                      Margin="0 5 10 5"
+              <Button Padding="5"
+                      Margin="0 5 5 5"
                       Grid.Row="0"
                       Grid.Column="2"
                       Background="Gray"
@@ -71,8 +71,8 @@
                   Foreground="White"
                   Text="{Binding DefaultServerLabel}"/>
               </Button>
-              <Button FontSize="10"
-                      Margin="0 5 10 5"
+              <Button Padding="5"
+                      Margin="0 5 5 5"
                       Grid.Row="0"
                       Grid.Column="3"
                       Background="Red"
@@ -86,8 +86,8 @@
                   Foreground="White"
                   Text="REMOVE"/>
               </Button>
-			  <Button FontSize="10"
-					Margin="0 5 10 5"
+			  <Button Padding="5"
+					Margin="0 5 5 5"
 					Grid.Row="0"
 					Grid.Column="4"
 					Background="Gray"


### PR DESCRIPTION

## Description & motivation

This change is to cater for other applications which have not implemented a full auth flow with Speckle - it allows users to grab their token from the Arup Speckle Account Manager and paste it into the required field from the clipboard

## Changes:

A new button in each connection line in the UI called "Copy token", which opens up a connection to the Sqlite DB and reads the current token.

Currently doesn't wait for thetimed refresh job to finish (so the token could be old if pressed quickly).

## To-do before merge:


## Screenshots:

![image](https://user-images.githubusercontent.com/51431496/221089024-5a4da5b3-42dd-46f1-bb9e-472a0631e2ba.png)

## Validation of changes:

No tests have been added or amended

## Checklist:

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

