### PR TITLE
Jm/dev/2.13 gsa

### DIFF
--- a/DesktopUI2/DesktopUI2/Views/Pages/HomeViewStandalone.axaml
+++ b/DesktopUI2/DesktopUI2/Views/Pages/HomeViewStandalone.axaml
@@ -76,6 +76,7 @@
                 <Menu
                   Grid.Column="5"
                   VerticalAlignment="Center"
+                  IsEnabled="{Binding !InProgress}"
                   Items="{Binding MenuItems}">
                     <Menu.Styles>
                         <Style Selector="MenuItem">
@@ -137,7 +138,7 @@
           Grid.Row="1"
           Margin="5,10,5,5"
           IsVisible="{Binding HasAccounts}"
-          RowDefinitions="auto,auto,auto,auto, *, auto">
+          RowDefinitions="auto,auto,auto,auto,auto, *, auto">
 
             <!--  NEW/OPEN FILE  -->
             <Grid
@@ -190,8 +191,6 @@
                     TextWrapping="Wrap"
                     TextTrimming="CharacterEllipsis" />
             </Grid>
-
-
             <!--  SEARCH STREAMS  -->
             <Grid Grid.Row="2" Margin="0">
                 <m:Card
@@ -337,8 +336,8 @@
               Margin="0,10,0,0"
               IsVisible="{Binding InProgress}">
                 <ProgressBar IsIndeterminate="True" />
-            </Grid>            
-            
+            </Grid>
+
 
             <ScrollViewer
               Grid.Row="5"

--- a/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Results/ConvertResults.cs
+++ b/Objects/Converters/ConverterCSI/ConverterCSIShared/Partial Classes/Results/ConvertResults.cs
@@ -76,7 +76,7 @@ namespace Objects.Converter.CSI
       var results1D = send1DResults ? AllResultSet1dToSpeckle(convertedFrameNames, convertedPierNames, convertedSpandrelNames) : null;
       var results2D = send2DResults ? AreaResultSet2dToSpeckle(convertedAreaNames) : null;
 
-      var results = new ResultSetAll(results1D, results2D, new ResultSet3D(), new ResultGlobal(), resultsNode);
+      var results = new ResultSetAll(results1D, results2D, new ResultSet3D(), new ResultSetGlobal(), resultsNode);
 
       return results;
     }

--- a/Objects/Objects/Structural/Results/ResultAll.cs
+++ b/Objects/Objects/Structural/Results/ResultAll.cs
@@ -20,7 +20,7 @@ namespace Objects.Structural.Results
     public ResultSet3D results3D { get; set; } //3d elements results
 
     [DetachProperty]
-    public ResultGlobal resultsGlobal { get; set; } //global results
+    public ResultSetGlobal resultsGlobal { get; set; } //global results
 
     [DetachProperty]
     public ResultSetNode resultsNode { get; set; } //nodal results
@@ -28,7 +28,7 @@ namespace Objects.Structural.Results
     public ResultSetAll() { }
 
     [SchemaInfo("ResultSetAll", "Creates a Speckle result set object for 1d element, 2d element, 3d element global and nodal results", "Structural", "Results")]
-    public ResultSetAll(ResultSet1D results1D, ResultSet2D results2D, ResultSet3D results3D, ResultGlobal resultsGlobal, ResultSetNode resultsNode)
+    public ResultSetAll(ResultSet1D results1D, ResultSet2D results2D, ResultSet3D results3D, ResultSetGlobal resultsGlobal, ResultSetNode resultsNode)
     {
       this.results1D = results1D;
       this.results2D = results2D;


### PR DESCRIPTION
- Update GSA connector to use ConnectorHelpers methods for handling receive operation
- Revert upstream change to global results prop in ResultSetAll class (ResultGlobal class is setup for 1-to-1 mapping between a single mode and/or load case and the associated results, so it doesn't make sense to represent a set of global results on a model with just a single ResultGlobal property)
- Add missing row definition in standalone HomeView to allow scrollviewer to work